### PR TITLE
Use orange for gas consumption

### DIFF
--- a/themes/nordic-blue.yaml
+++ b/themes/nordic-blue.yaml
@@ -98,7 +98,7 @@
   warning-color: var(--orange-color)
   success-color: var(--green-color)
   info-color: var(--blue-color)
-  
+
   # Energy
   energy-grid-consumption-color: "var(--frost-steel-blue)"
   energy-grid-return-color: "var(--frost-cadet-blue)"
@@ -106,8 +106,8 @@
   energy-non-fossil-color: "var(--aurora-green)"
   energy-battery-out-color: "var(--aurora-red)"
   energy-battery-in-color: "var(--aurora-pink)"
-  energy-gas-color: "var(--polar-dark-gray)"
-  energy-water-color: "var(--aurora-blue)" 
+  energy-gas-color: "var(--aurora-orange)"
+  energy-water-color: "var(--aurora-blue)"
 
   modes:
     light:

--- a/themes/nordic.yaml
+++ b/themes/nordic.yaml
@@ -98,7 +98,7 @@ Nordic:
   warning-color: var(--orange-color)
   success-color: var(--green-color)
   info-color: var(--blue-color)
-  
+
   # Energy
   energy-grid-consumption-color: "var(--frost-steel-blue)"
   energy-grid-return-color: "var(--frost-cadet-blue)"
@@ -106,8 +106,8 @@ Nordic:
   energy-non-fossil-color: "var(--aurora-green)"
   energy-battery-out-color: "var(--aurora-red)"
   energy-battery-in-color: "var(--aurora-pink)"
-  energy-gas-color: "var(--polar-dark-gray)"
-  energy-water-color: "var(--aurora-blue)" 
+  energy-gas-color: "var(--aurora-orange)"
+  energy-water-color: "var(--aurora-blue)"
 
   modes:
     light:


### PR DESCRIPTION
This PR switches the colour for gas consumption on the energy dashboard from `polar-dark-gray` to `aurora-orange` to make things look better as the dark grey against the blue-grey background is hard to see.

I've opted for orange as it should compliment the other colours already used on the energy dashboard.

Before:

![Screenshot 2025-05-16 at 10 55 26](https://github.com/user-attachments/assets/eb300947-f74e-4aac-be75-263a61980dd1)

![Screenshot 2025-05-16 at 10 55 17](https://github.com/user-attachments/assets/0484577b-0b12-420f-8161-4889cc1d5e64)


After:

![Screenshot 2025-05-16 at 11 12 23](https://github.com/user-attachments/assets/fed2f9a3-b942-44d3-86dc-ef002443350b)

![Screenshot 2025-05-16 at 11 12 27](https://github.com/user-attachments/assets/57674141-4b85-4e8b-86b2-54f244407af4)
